### PR TITLE
Move the specification of the MT chromosome to Select Reference dialog

### DIFF
--- a/src/IO/DataTypeDialogue.form
+++ b/src/IO/DataTypeDialogue.form
@@ -155,17 +155,6 @@
               <toolTipText value="Check this if you'd like to filter out reads mapping to MT chromosome. In this case specify the FastA identifier for the MT chromosome."/>
             </properties>
           </component>
-          <component id="2e98" class="javax.swing.JTextField" binding="mtcapture_jtextfield">
-            <constraints>
-              <grid row="7" column="2" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="1" use-parent-layout="false">
-                <preferred-size width="150" height="-1"/>
-              </grid>
-            </constraints>
-            <properties>
-              <enabled value="false"/>
-              <toolTipText value="Enter the ID of the MT chromosome here, if you do have MT capture data."/>
-            </properties>
-          </component>
           <component id="16829" class="javax.swing.JComboBox" binding="capture_type_combobox">
             <constraints>
               <grid row="4" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>

--- a/src/IO/DataTypeDialogue.java
+++ b/src/IO/DataTypeDialogue.java
@@ -31,7 +31,6 @@ public class DataTypeDialogue extends JDialog {
     private JCheckBox input_already_merged_jcheckbox;
     private JCheckBox merge_all_lanes_jcheckbox;
     private JCheckBox mt_capture_jcheckbox;
-    private JTextField mtcapture_jtextfield;
     private JComboBox capture_type_combobox;
     private JButton capture_button_select;
     private JButton capture_mt_button_select;
@@ -40,7 +39,7 @@ public class DataTypeDialogue extends JDialog {
         setContentPane(contentPane);
         setModal(true);
         getRootPane().setDefaultButton(buttonOK);
-        mtcapture_jtextfield.setText(communicator.getFilter_for_mt());
+
 
         buttonOK.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
@@ -51,10 +50,8 @@ public class DataTypeDialogue extends JDialog {
             @Override
             public void actionPerformed(ActionEvent e) {
                 if(mt_capture_jcheckbox.isSelected()){
-                    mtcapture_jtextfield.setEnabled(true);
                     capture_mt_button_select.setEnabled(true);
                 } else {
-                    mtcapture_jtextfield.setEnabled(false);
                     capture_mt_button_select.setEnabled(false);
                 }
             }
@@ -136,7 +133,6 @@ public class DataTypeDialogue extends JDialog {
 
         if(mt_capture_jcheckbox.isSelected()) {
             c.setRun_mt_capture_mode(true);
-            c.setFilter_for_mt(mtcapture_jtextfield.getText());
         } else {
             c.setRun_mt_capture_mode(false);
         }

--- a/src/IO/ReferenceDialog.form
+++ b/src/IO/ReferenceDialog.form
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="IO.ReferenceDialog">
+  <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="10" left="10" bottom="10" right="10"/>
+    <constraints>
+      <xy x="48" y="54" width="436" height="297"/>
+    </constraints>
+    <properties/>
+    <border type="none"/>
+    <children>
+      <grid id="94766" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <hspacer id="98af6">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </hspacer>
+          <grid id="9538f" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="true" same-size-vertically="false" hgap="-1" vgap="-1">
+            <margin top="0" left="0" bottom="0" right="0"/>
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+            <border type="none"/>
+            <children>
+              <component id="e7465" class="javax.swing.JButton" binding="buttonOK">
+                <constraints>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="OK"/>
+                </properties>
+              </component>
+              <component id="5723f" class="javax.swing.JButton" binding="buttonCancel">
+                <constraints>
+                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Cancel"/>
+                </properties>
+              </component>
+            </children>
+          </grid>
+        </children>
+      </grid>
+      <grid id="e3588" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="49622" class="javax.swing.JButton" binding="referenceButton" default-binding="true">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Select Reference"/>
+              <toolTipText value="Select your reference sequence in FASTA format here. You do not need to create indices, these will be created if required by the pipeline itself."/>
+            </properties>
+          </component>
+          <component id="cfc90" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Name of mitochondrial chromosome"/>
+            </properties>
+          </component>
+          <component id="18bd9" class="javax.swing.JTextField" binding="mtcapture_jtextfield">
+            <constraints>
+              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="150" height="-1"/>
+              </grid>
+            </constraints>
+            <properties>
+              <toolTipText value="Enter the ID of the MT chromosome here."/>
+            </properties>
+          </component>
+          <component id="a9522" class="javax.swing.JTextPane" binding="pleaseInputTheNameTextPane" default-binding="true">
+            <constraints>
+              <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="7" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
+                <preferred-size width="150" height="40"/>
+              </grid>
+            </constraints>
+            <properties>
+              <text value="Please input the name of the mitochondrial chromosome. This is used in calculating coverage statistics and for MT capture experiments. &#10;&#10;Remember to use chrMT for HG19 and MT for hs37d5"/>
+            </properties>
+          </component>
+        </children>
+      </grid>
+    </children>
+  </grid>
+</form>

--- a/src/IO/ReferenceDialog.java
+++ b/src/IO/ReferenceDialog.java
@@ -1,0 +1,89 @@
+package IO;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.*;
+
+public class ReferenceDialog extends JDialog {
+    private JPanel contentPane;
+    private JButton buttonOK;
+    private JButton buttonCancel;
+    private JButton referenceButton;
+    private JTextField mtcapture_jtextfield;
+    private JTextPane pleaseInputTheNameTextPane;
+    private Communicator communicator;
+    private JButton runButton;
+
+    public ReferenceDialog(final Communicator communicator, JButton runButton) {
+        setContentPane(contentPane);
+        setModal(true);
+        getRootPane().setDefaultButton(buttonOK);
+        mtcapture_jtextfield.setText(communicator.getFilter_for_mt());
+        this.communicator = communicator;
+        this.runButton = runButton;
+
+        buttonOK.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                onOK();
+            }
+        });
+
+        buttonCancel.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                onCancel();
+            }
+        });
+
+        referenceButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent actionEvent) {
+                ReferenceFastAChooser rffqc = new ReferenceFastAChooser(communicator);
+                referenceButton.setForeground(Color.green);
+
+                if (checkIfInputWasSelected()) {
+                    runButton.setEnabled(true);
+                    buttonOK.setEnabled(true);
+                } else {
+                    runButton.setEnabled(false);
+                    buttonCancel.setEnabled(false);
+                }
+            }
+        });
+
+// call onCancel() when cross is clicked
+        setDefaultCloseOperation(DO_NOTHING_ON_CLOSE);
+        addWindowListener(new WindowAdapter() {
+            public void windowClosing(WindowEvent e) {
+                onCancel();
+            }
+        });
+
+// call onCancel() on ESCAPE
+        contentPane.registerKeyboardAction(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                onCancel();
+            }
+        }, KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT);
+    }
+
+    private void onOK() {
+// add your code here
+        this.communicator.setFilter_for_mt(this.mtcapture_jtextfield.getText());
+        dispose();
+    }
+
+    private void onCancel() {
+// add your code here if necessary
+        dispose();
+    }
+
+    private boolean checkIfInputWasSelected() {
+        boolean tmp = false;
+        if (communicator.getGUI_inputfiles() != null && communicator.getGUI_reference() != null && communicator.getGUI_resultspath() != null) {
+            if(communicator.getGUI_inputfiles().size() != 0){
+                tmp = true;
+            }
+        }
+        return tmp;
+    }
+}

--- a/src/main/DeDupDialog.form
+++ b/src/main/DeDupDialog.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="contentPane" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="10" left="10" bottom="10" right="10"/>
     <constraints>
-      <xy x="20" y="20" width="1742" height="3285"/>
+      <xy x="20" y="20" width="1742" height="4240"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -94,7 +94,7 @@
                   <enabled value="true"/>
                   <lineWrap value="true"/>
                   <rows value="6"/>
-                  <text value="This option applies if you are using the DeDup tool:&#10;&#10;Check this box unless your read names have prefixes indicating merged, forward or reverse (M_,F_,R_).&#10;&#10;If your reads are NOT from ClipAndMerge then you will probably want to check this box."/>
+                  <text value="This option applies if you are using the DeDup tool:&#10;&#10;Check this box unless your read names have prefixes indicating merged, read one or read two (M_,F_,R_).&#10;&#10;If your reads are NOT from ClipAndMerge then you will probably want to check this box. By checking this box, read names will be ignored and all reads are treated as merged."/>
                   <wrapStyleWord value="true"/>
                 </properties>
               </component>

--- a/src/main/EAGER.java
+++ b/src/main/EAGER.java
@@ -349,14 +349,10 @@ public class EAGER {
         referenceButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent actionEvent) {
-                ReferenceFastAChooser rffqc = new ReferenceFastAChooser(communicator);
+                ReferenceDialog rd = new ReferenceDialog(communicator, RunButton);
+                rd.setSize(600, 400);
+                rd.setVisible(true);
                 referenceButton.setForeground(Color.green);
-
-                if (checkIfInputWasSelected()) {
-                    RunButton.setEnabled(true);
-                } else {
-                    RunButton.setEnabled(false);
-                }
             }
         });
 


### PR DESCRIPTION
This allows users to specify the name of the mitochondrial chromosome so that the mttonucratiocalculator can produce stats for mito coverage. Previously this was only available when selecting MT Capture.
