### PR TITLE
Bug fix

### DIFF
--- a/src/main/DamageProfilerDialog.form
+++ b/src/main/DamageProfilerDialog.form
@@ -98,8 +98,8 @@
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <text value="use all mapped reads"/>
-          <toolTipText value="Don't use this for single-end reads."/>
+          <text value="use only merged reads"/>
+          <toolTipText value="Don't use this for single-end reads"/>
         </properties>
       </component>
     </children>

--- a/src/main/DamageProfilerDialog.form
+++ b/src/main/DamageProfilerDialog.form
@@ -93,7 +93,7 @@
           </component>
         </children>
       </grid>
-      <component id="a8626" class="javax.swing.JCheckBox" binding="useAllMappedReadsCheckBox" default-binding="true">
+      <component id="a8626" class="javax.swing.JCheckBox" binding="useOnlyMergedReadsCheckBox">
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>

--- a/src/main/DamageProfilerDialog.java
+++ b/src/main/DamageProfilerDialog.java
@@ -73,7 +73,6 @@ public class DamageProfilerDialog extends JDialog {
         if(c.getMapdamage_length() != null){
             this.DamageProfiler_length_field.setText(c.getMapdamage_length());
         }
-
     }
 
 }

--- a/src/main/DamageProfilerDialog.java
+++ b/src/main/DamageProfilerDialog.java
@@ -53,9 +53,8 @@ public class DamageProfilerDialog extends JDialog {
         c.setMapdamage_advanced(DamageProfiler_advanced_field.getText());
         c.setMapdamage_length(DamageProfiler_length_field.getText());
         if(useOnlyMergedReadsCheckBox.isSelected()){
+            DamageProfiler_advanced_field.setText(DamageProfiler_advanced_field.getText() + " -merged");
             c.setDamageProfilerOnlyMerged(true);
-        } else {
-            c.setDamageProfilerOnlyMerged(false);
         }
         dispose();
     }

--- a/src/main/DamageProfilerDialog.java
+++ b/src/main/DamageProfilerDialog.java
@@ -13,7 +13,7 @@ public class DamageProfilerDialog extends JDialog {
     private JTextField DamageProfiler_advanced_field;
     private JLabel advanced;
     private JLabel length;
-    private JCheckBox useAllMappedReadsCheckBox;
+    private JCheckBox useOnlyMergedReadsCheckBox;
 
     public DamageProfilerDialog(final Communicator communicator) {
         setValues(communicator);
@@ -52,10 +52,10 @@ public class DamageProfilerDialog extends JDialog {
     private void onOK(Communicator c) {
         c.setMapdamage_advanced(DamageProfiler_advanced_field.getText());
         c.setMapdamage_length(DamageProfiler_length_field.getText());
-        if(useAllMappedReadsCheckBox.isSelected()){
-            c.setDamageProfilerOnlyMerged(false);
-        } else {
+        if(useOnlyMergedReadsCheckBox.isSelected()){
             c.setDamageProfilerOnlyMerged(true);
+        } else {
+            c.setDamageProfilerOnlyMerged(false);
         }
         dispose();
     }


### PR DESCRIPTION
'use all mapped reads' is now default -> avoids problems with single-end reads
