### PR TITLE
Bug fix

### DIFF
--- a/src/main/java/main/DamageProfilerDialog.form
+++ b/src/main/java/main/DamageProfilerDialog.form
@@ -93,12 +93,12 @@
           </component>
         </children>
       </grid>
-      <component id="a8626" class="javax.swing.JCheckBox" binding="useAllMappedReadsCheckBox" default-binding="true">
+      <component id="a8626" class="javax.swing.JCheckBox" binding="useOnlyMergedReadsCheckBox">
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <text value="use all mapped reads"/>
+          <text value="use only merged reads"/>
           <toolTipText value="Don't use this for single-end reads."/>
         </properties>
       </component>


### PR DESCRIPTION
'use all mapped reads' is now default -> avoids problems with single-end reads
