### PR TITLE
WIP start to fix adapter removal for single end reads

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'com.uni-tuebingen.de.it.eager.eager-gui'
-version '1.92.37'
+version '1.92.38'
 
 
 buildscript {

--- a/src/main/java/main/AdapterRemovalDialog.form
+++ b/src/main/java/main/AdapterRemovalDialog.form
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="main.AdapterRemovalDialog">
-  <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="5" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="6" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="10" left="10" bottom="10" right="10"/>
     <constraints>
-      <xy x="48" y="54" width="436" height="322"/>
+      <xy x="48" y="54" width="436" height="347"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -11,7 +11,7 @@
       <grid id="94766" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -169,6 +169,14 @@
         <properties>
           <selected value="false"/>
           <text value="Keep merged only"/>
+        </properties>
+      </component>
+      <component id="5c889" class="javax.swing.JCheckBox" binding="qualityBase64CheckBox">
+        <constraints>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Quality base 64"/>
         </properties>
       </component>
     </children>

--- a/src/main/java/main/AdapterRemovalDialog.java
+++ b/src/main/java/main/AdapterRemovalDialog.java
@@ -19,6 +19,7 @@ public class AdapterRemovalDialog extends JDialog {
     private JTextField forward_adapter_textfield;
     private JTextField reverse_adapter_textfield;
     private JCheckBox adapter_merged_only;
+    private JCheckBox qualityBase64CheckBox;
 
     public AdapterRemovalDialog(Communicator communicator) {
         setValues(communicator);
@@ -62,6 +63,7 @@ public class AdapterRemovalDialog extends JDialog {
         c.setMerge_only_clipping(performOnlyAdapterClippingCheckBox.isSelected());
         c.setMerge_min_adapter_overlap(Integer.parseInt(minimum_adapter_overlap_textfield.getText()));
         c.setMerge_keep_only_merged(adapter_merged_only.isSelected());
+        c.setQualityBase64(qualityBase64CheckBox.isSelected());
         c.setMerge_tool("AdapterRemoval");
         dispose();
     }
@@ -89,6 +91,7 @@ public class AdapterRemovalDialog extends JDialog {
             this.minimum_adapter_overlap_textfield.setText(String.valueOf(c.getMerge_min_adapter_overlap()));
         }
         this.adapter_merged_only.setSelected(c.isMerge_keep_only_merged());
+        this.qualityBase64CheckBox.setSelected(c.isQualityBase64());
     }
 
     {
@@ -107,10 +110,10 @@ public class AdapterRemovalDialog extends JDialog {
      */
     private void $$$setupUI$$$() {
         contentPane = new JPanel();
-        contentPane.setLayout(new GridLayoutManager(5, 1, new Insets(10, 10, 10, 10), -1, -1));
+        contentPane.setLayout(new GridLayoutManager(6, 1, new Insets(10, 10, 10, 10), -1, -1));
         final JPanel panel1 = new JPanel();
         panel1.setLayout(new GridLayoutManager(1, 1, new Insets(0, 0, 0, 0), -1, -1));
-        contentPane.add(panel1, new GridConstraints(4, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, 1, null, null, null, 0, false));
+        contentPane.add(panel1, new GridConstraints(5, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, 1, null, null, null, 0, false));
         final JPanel panel2 = new JPanel();
         panel2.setLayout(new GridLayoutManager(1, 2, new Insets(0, 0, 0, 0), -1, -1, true, false));
         panel1.add(panel2, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
@@ -163,6 +166,9 @@ public class AdapterRemovalDialog extends JDialog {
         adapter_merged_only.setSelected(false);
         adapter_merged_only.setText("Keep merged only");
         contentPane.add(adapter_merged_only, new GridConstraints(3, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        qualityBase64CheckBox = new JCheckBox();
+        qualityBase64CheckBox.setText("Quality base 64");
+        contentPane.add(qualityBase64CheckBox, new GridConstraints(4, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
     }
 
     /**

--- a/src/main/java/main/EAGER.java
+++ b/src/main/java/main/EAGER.java
@@ -762,11 +762,6 @@ public class EAGER {
         communicator.setGatk_caller(genotyper.getSelectedItem().toString());
         communicator.setRun_fastqc(fastQCAnalysisCheckBox.isSelected());
         communicator.setMerge_tool(merge_tool_combobox.getSelectedItem().toString());
-
-        if (merge_tool_combobox.getSelectedItem().toString().equals("AdapterRemoval")) {
-            communicator.setRmdup_all_reads_as_merged(true);
-        }
-
         communicator.setRun_cleanup(cleanUpBox.isSelected());
         communicator.setRun_clipandmerge(merge.isSelected());
         communicator.setRun_complexityestimation(complexity.isSelected());


### PR DESCRIPTION
There will likely be some changes required to lib and cli for this to work, but this can serve as an issue.

Right now the fix for GUI is to stop always setting the treat all reads as merged option for DeDup.